### PR TITLE
Release/1.0.2

### DIFF
--- a/best.ellie.StartupConfiguration.json
+++ b/best.ellie.StartupConfiguration.json
@@ -42,8 +42,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/ellieplayswow/startup-configuration.git",
-          "commit": "be941401a84a928d37525fcdcf1226628548f5b2"
+          "url": "https://codeberg.org/ellie1337/startup-configuration.git",
+          "commit": "13bddce6c4157af72176d98783b3af4cfa96f788"
         },
         "./cargo-sources.json"
       ]

--- a/best.ellie.StartupConfiguration.json
+++ b/best.ellie.StartupConfiguration.json
@@ -43,7 +43,7 @@
         {
           "type": "git",
           "url": "https://codeberg.org/ellie1337/startup-configuration.git",
-          "commit": "13bddce6c4157af72176d98783b3af4cfa96f788"
+          "commit": "217338ebab1cc9e5ab675a5138a4ae972cc90063"
         },
         "./cargo-sources.json"
       ]


### PR DESCRIPTION
this also moves the canonical source for the repository to codeberg, as per https://codeberg.org/ellie1337/startup-configuration/issues/11